### PR TITLE
added getSingleScalarResult

### DIFF
--- a/src/Test/ORM/QueryBuilderMocker.php
+++ b/src/Test/ORM/QueryBuilderMocker.php
@@ -52,6 +52,7 @@ class QueryBuilderMocker extends BaseQueryBuilderMocker
         'execute',
         'useResultCache',
         'getSingleResult',
+        'getSingleScalarResult',
     );
 
     /**
@@ -66,7 +67,7 @@ class QueryBuilderMocker extends BaseQueryBuilderMocker
             ->disableOriginalConstructor()
             ->getMock();
         $this->query = $testCase->getMockBuilder('StubQuery') // can't mock Doctrine's "Query" because it's "final"
-            ->setMethods(array('execute', 'useResultCache', 'getSingleResult'))
+            ->setMethods(array('execute', 'useResultCache', 'getSingleResult', 'getSingleScalarResult'))
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -117,5 +118,36 @@ class QueryBuilderMocker extends BaseQueryBuilderMocker
         }
 
         return $this;
+    }
+
+    /**
+     * @param array $args
+     * @return $this
+     */
+    protected function getSingleScalarResult(array $args)
+    {
+        $invocationMocker = $this->query->expects($this->testCase->once())->method('getSingleScalarResult');
+
+        if (count($args) > 0) {
+            $invocationMocker->will($this->testCase->returnValue($args[0]));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Override for methods that are specific to ORM
+     *
+     * @param string $method
+     * @param array $args
+     * @return $this|QueryBuilderMocker
+     */
+    public function __call($method, array $args)
+    {
+        if ($method === 'getSingleScalarResult') {
+            return $this->getSingleScalarResult($args);
+        }
+
+        return parent::__call($method, $args);
     }
 }

--- a/test/Test/ORM/QueryBuilderMockerTest.php
+++ b/test/Test/ORM/QueryBuilderMockerTest.php
@@ -86,6 +86,17 @@ class QueryBuilderMockerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('it works!', $qb->getQuery()->getSingleResult());
     }
 
+    public function testGetSingleScalarResultReturnsValue()
+    {
+        $qbm = new QueryBuilderMocker($this);
+        $qbm->getQuery()
+            ->getSingleScalarResult('it works!');
+
+        $qb = $qbm->getQueryBuilderMock();
+
+        $this->assertEquals('it works!', $qb->getQuery()->getSingleScalarResult());
+    }
+
     public function testEmptyGetSingleResultIsNull()
     {
         $qbm = new QueryBuilderMocker($this);


### PR DESCRIPTION
ORM has method getSingleScalarResult. It is useful to have this method implemented too. There might be others left to implement. Overriding  method __call was the only way I found to implement this, but I don't think it's a big deal.