### PR TITLE
getQueryMock method for more flexiblity.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 vendor
+test/code-coverage

--- a/src/Test/QueryBuilderMocker.php
+++ b/src/Test/QueryBuilderMocker.php
@@ -103,6 +103,16 @@ abstract class QueryBuilderMocker
     }
 
     /**
+     * Returns the final mocked query.
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    public function getQueryMock()
+    {
+        return $this->query;
+    }
+
+    /**
      * Handles mocking of execute() calls, which are a special case.
      *
      * @param array|null $args

--- a/test/Test/ORM/QueryBuilderMockerTest.php
+++ b/test/Test/ORM/QueryBuilderMockerTest.php
@@ -170,4 +170,21 @@ class QueryBuilderMockerTest extends PHPUnit_Framework_TestCase
         $qbm = new QueryBuilderMocker($this);
         $qbm->expr();
     }
+
+    /**
+     * @author Lauri Orgla <theorx@hotmail.com>
+     * @covers \MMoussa\Doctrine\Test\ORM\QueryBuilderMocker::getQueryMock
+     */
+    public function testGetQueryMockReturnsMockObject()
+    {
+
+        $qbm = new QueryBuilderMocker($this);
+        $qbm->getQuery()
+            ->execute();
+
+        $queryMock = $qbm->getQueryMock();
+        $queryBuilderMock = $qbm->getQueryBuilderMock();
+        $this->assertInstanceOf('\PHPUnit_Framework_MockObject_MockObject', $queryMock);
+        $this->assertNull($queryBuilderMock->getQuery()->execute());
+    }
 }


### PR DESCRIPTION
Hi!

I created this method for more flexibility in testing. For example i had to throw an __Exception__ in `$query->getResult()` method and i was unable to pass callback as a parameter to throw new exception in the callback. So as a workaround i had to call `$qbm->getQuery()` and after getting `$mockQueryBuilder` call `$mockQueryBuilder->getQuery()` to get PHPUnit's __mock object__. 

So this method i implemented allows me to get the mockQuery object without mocking getQuery method first. 

Example for the code:

```php
     public function someFunction (){

     ....

      $qb->setParameters($parameters);
	        try {
	            return $qb->getQuery()->getResult();
	        } catch (\Exception $e) {
	            return false;
	        }
    }

```

And the test:

```php

 $qbm = new QueryBuilderMocker($this);
        //$qbm->getQuery here is workaround
        $qbm->getQuery();
 
       ...

        $qbm->setParameters($parameters);
        $qbm->getQuery();
        $qbm = $qbm->getQueryBuilderMock();

        //$mock for workaround
        $mock = $qbm->getQuery();
        /**
         * @var \PHPUnit_Framework_MockObject_MockObject $mock
         */
        $mock->expects($this->once())->method('getResult')->willReturnCallback(function () {

            throw new \Exception;
        });

       // Call the actual method described above
      $object->someFunction();

```
