### PR TITLE
Test on php 7.0 in travis.ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 5.5
     - 5.6
+    - 7.0
 
 before_script:
     - echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini


### PR DESCRIPTION
I suggest adding php 7.0 to tested versions in travis. If everything goes well then composer.json could be changed to allow installation on php7 too (e.g. `"php": ">=5.4"`).

